### PR TITLE
fix: 还原vision_camera权限配置中的abilities字段

### DIFF
--- a/package/harmony/vision_camera/src/main/module.json5
+++ b/package/harmony/vision_camera/src/main/module.json5
@@ -9,56 +9,32 @@
       {
         "name": "ohos.permission.CAMERA",
         "reason": "$string:camera_reason",
-        "usedScene": {
-          "abilities": [
-            "EntryAbility"
-          ]
-        }
+        "usedScene": {}
       },
       {
         "name": "ohos.permission.MICROPHONE",
         "reason": "$string:microphone_reason",
-        "usedScene": {
-          "abilities": [
-            "EntryAbility"
-          ]
-        }
+        "usedScene": {}
       },
       {
         "name": "ohos.permission.MEDIA_LOCATION",
         "reason": "$string:media_location_reason",
-        "usedScene": {
-          "abilities": [
-            "EntryAbility"
-          ]
-        }
+        "usedScene": {}
       },
       {
         "name": "ohos.permission.APPROXIMATELY_LOCATION",
         "reason": "$string:location_reason",
-        "usedScene": {
-          "abilities": [
-            "EntryAbility"
-          ]
-        }
+        "usedScene": {}
       },
       {
         "name": "ohos.permission.WRITE_IMAGEVIDEO",
         "reason": "$string:write_media",
-        "usedScene": {
-          "abilities": [
-            "EntryAbility"
-          ]
-        }
+        "usedScene": {}
       },
       {
         "name": "ohos.permission.READ_IMAGEVIDEO",
         "reason": "$string:read_media",
-        "usedScene": {
-          "abilities": [
-            "EntryAbility"
-          ]
-        }
+        "usedScene": {}
       }
     ]
   }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
