### PR TITLE
fix:修复 react-native-vision-camera 返回桌面再从桌面回到应用扫描无法预览问题

### DIFF
--- a/package/harmony/vision_camera/src/main/ets/VisionCameraView.ets
+++ b/package/harmony/vision_camera/src/main/ets/VisionCameraView.ets
@@ -55,6 +55,7 @@ const TAG: string = 'VisionCameraView:'
 
 @Component
 export struct VisionCameraView {
+  private callbackList:Array<()=> void> =[]
   public static readonly NAME = VisionCameraViewSpec.NAME
   public ctx!: RNComponentContext
   public tag: number = 0
@@ -181,7 +182,7 @@ export struct VisionCameraView {
    */
   subscribeToLifecycleEvents() {
     Logger.info(TAG, `subscribeToLifecycleEvents start`);
-    this.ctx.rnInstance.subscribeToLifecycleEvents("FOREGROUND", () => {
+    this.callbackList.push(this.ctx.rnInstance.subscribeToLifecycleEvents("FOREGROUND", () => {
       Logger.info(TAG, `subscribeToLifecycleEvents FOREGROUND`);
       const props = this.descriptorWrapper['descriptor'].rawProps;
       if (this.cameraState === cameraState.SCAN) {
@@ -211,7 +212,8 @@ export struct VisionCameraView {
         }
       }
     })
-    this.ctx.rnInstance.subscribeToLifecycleEvents("BACKGROUND", async () => {
+    )
+    this.callbackList.push(this.ctx.rnInstance.subscribeToLifecycleEvents("BACKGROUND", async () => {
       Logger.info(TAG, `subscribeToLifecycleEvents BACKGROUND`);
       if (this.cameraState === cameraState.SCAN) {
         clearTimeout(this.timer)
@@ -219,7 +221,8 @@ export struct VisionCameraView {
         this.scanSession.scanRelease();
         Logger.info(TAG, `subscribeToLifecycleEvents BACKGROUND , ${JSON.stringify(this.scanSession)}`);
       }
-    })
+    }))
+
     this.ctx.rnInstance.subscribeToLifecycleEvents("CONFIGURATION_UPDATE", () => {
       Logger.info(TAG, `subscribeToLifecycleEvents CONFIGURATION_UPDATE`);
     })
@@ -354,6 +357,7 @@ export struct VisionCameraView {
       await this.cameraSession.cameraRelease();
     }
     this.cleanCommandCallback?.();
+    this.this.cancellationCallback()
   }
 
   registerCommandCallback() {
@@ -563,6 +567,13 @@ export struct VisionCameraView {
    */
   resumeRecording() {
     this.cameraSession.resumeRecording()
+  }
+  cancellationCallback(){
+      this.this.callbackList.forEach(
+        callback =>{
+          callback?.()
+        }
+      )
   }
 
   build() {


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What
fix:修复 react-native-vision-camera 返回桌面再从桌面回到应用扫描无法预览问题，增加 aboutToDisappear 生命周期注销返回桌面监听。
<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
