### PR TITLE
fix:修改resizeMode为contain时画面显示问题

### DIFF
--- a/package/harmony/vision_camera/src/main/ets/service/CameraSession.ts
+++ b/package/harmony/vision_camera/src/main/ets/service/CameraSession.ts
@@ -299,7 +299,7 @@ export default class CameraSession {
     this.cameraInput.open();
     this.capability = this.cameraManager.getSupportedOutputCapability(currentDevice, camera.SceneMode.NORMAL_PHOTO);
     if (surfaceId && props.preview) {
-      //this.previewProfile = this.capability.previewProfiles[this.capability.previewProfiles.length - 1];
+      // previewProfile是通过this.capability.previewProfiles获取的，这里和OS沟通可设置为通用的1920和1080
       this.previewProfile = {
         format:1003,
         size:{

--- a/package/harmony/vision_camera/src/main/ets/service/CameraSession.ts
+++ b/package/harmony/vision_camera/src/main/ets/service/CameraSession.ts
@@ -299,7 +299,14 @@ export default class CameraSession {
     this.cameraInput.open();
     this.capability = this.cameraManager.getSupportedOutputCapability(currentDevice, camera.SceneMode.NORMAL_PHOTO);
     if (surfaceId && props.preview) {
-      this.previewProfile = this.capability.previewProfiles[this.capability.previewProfiles.length - 1];
+      //this.previewProfile = this.capability.previewProfiles[this.capability.previewProfiles.length - 1];
+      this.previewProfile = {
+        format:1003,
+        size:{
+          width:1920,
+          height:1080
+        }
+      }
       Logger.info(TAG, `initPhotoSession createCameraInput ${JSON.stringify(this.previewProfile)})`);
       this.previewOutput = this.cameraManager.createPreviewOutput(this.previewProfile, surfaceId);
     }


### PR DESCRIPTION

## What
fix:修改resizeMode为contain时画面显示问题

## Changes
在获取previewProfile分辨率不能取返回数组的最后一个，修改为常见通用的分辨率大小，size: { width:1920, height:1080 }

## Tested on

* Huawai mate60 pro
* Huawai mate60 

## Related issues


