### PR TITLE
fixed：[Issues: #53] 去除拍照时多了保存到相册的逻辑

### DIFF
--- a/package/harmony/vision_camera/src/main/ets/VisionCameraView.ets
+++ b/package/harmony/vision_camera/src/main/ets/VisionCameraView.ets
@@ -305,7 +305,7 @@ export struct VisionCameraView {
       Logger.info(TAG, `updateProps, videoStabilizationModeChange: ${props.videoStabilizationMode}`);
       this.cameraSession.setVideoStabilizationMode(false, props.videoStabilizationMode);
     }
-    this.cameraSession.setResizeMode(props.resizeMode, this.localDisplay?.width, this.localDisplay?.height,
+    this.cameraSession.setResizeMode(props.resizeMode, this.localDisplayWidth, this.localDisplayHeight,
       (width, height) => {
         this.componentWidth = width;
         this.componentHeight = height;

--- a/package/harmony/vision_camera/src/main/ets/service/CameraSession.ts
+++ b/package/harmony/vision_camera/src/main/ets/service/CameraSession.ts
@@ -392,7 +392,8 @@ export default class CameraSession {
     }
     let videoConfig: media.AVRecorderProfile = {
       fileFormat: media.ContainerFormatType.CFT_MPEG_4,
-      videoBitrate: videoBitRate * 70_000_000,
+      // videoBitrate: videoBitRate * 70_000_000,
+      videoBitrate: 512000,
       videoCodec: options.videoCodec === 'h265' ? media.CodecMimeType.VIDEO_HEVC : media.CodecMimeType.VIDEO_AVC,
       videoFrameWidth: this.videoSize.width,
       videoFrameHeight: this.videoSize.height,
@@ -404,11 +405,11 @@ export default class CameraSession {
     } : videoConfig
     this.videoUri = `${this.basicPath}/${this.outPathArray[1]}/${Date.now()}.${options.fileType || 'mp4'}`;
     // 点击开始录制才询问是否保存到图库,此时options.fileType不是undefined
-    if (options.fileType != undefined) {
-      this.videoUri =
-        await this.getMediaLibraryUri(this.videoUri, `${Date.now()}`, `${options.fileType || 'mp4'}`,
-          photoAccessHelper.PhotoType.VIDEO)
-    }
+    // if (options.fileType != undefined) {
+    //   this.videoUri =
+    //     await this.getMediaLibraryUri(this.videoUri, `${Date.now()}`, `${options.fileType || 'mp4'}`,
+    //       photoAccessHelper.PhotoType.VIDEO)
+    // }
     this.videoFile = fs.openSync(this.videoUri, fs.OpenMode.READ_WRITE | fs.OpenMode.CREATE);
     let aVAudio = {
       audioSourceType: media.AudioSourceType.AUDIO_SOURCE_TYPE_MIC
@@ -706,7 +707,9 @@ export default class CameraSession {
         Logger.error(TAG, `setPhotoOutputCb photoAssetAvailable failed, ${JSON.stringify(err)}`);
         return;
       }
-      this.savePicture(photoAsset);
+      const uri = photoAsset.get('uri') as string;
+      this.photoPath = uri;
+      // this.savePicture(photoAsset);
     });
   }
 


### PR DESCRIPTION
# Summary

- 删除拍照和录制视频时保存到相册逻辑和ios端保持一致

## Related issues
Closes #53  


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [x] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

