### PR TITLE
fixed：[Issues: #64] 修复拍照保存到相册的路径不是沙箱路径

### DIFF
--- a/package/harmony/vision_camera/src/main/ets/service/CameraSession.ts
+++ b/package/harmony/vision_camera/src/main/ets/service/CameraSession.ts
@@ -688,7 +688,7 @@ export default class CameraSession {
   // 保存图片
   async savePicture(photoAccess: photoAccessHelper.PhotoAsset): Promise<void> {
     let photoFile = `${this.basicPath}/${this.outPathArray[0]}/${Date.now().toString()}.jpeg`;
-    photoFile = await this.getMediaLibraryUri(photoFile, `${Date.now()}`, 'jpeg', photoAccessHelper.PhotoType.IMAGE)
+    // photoFile = await this.getMediaLibraryUri(photoFile, `${Date.now()}`, 'jpeg', photoAccessHelper.PhotoType.IMAGE)
     // 根据相机拍照图片路径，获取文件buffer
     let file = fs.openSync(photoAccess.uri, fs.OpenMode.READ_ONLY);
     let stat = fs.statSync(file.fd);
@@ -713,9 +713,7 @@ export default class CameraSession {
         Logger.error(TAG, `setPhotoOutputCb photoAssetAvailable failed, ${JSON.stringify(err)}`);
         return;
       }
-      const uri = photoAsset.get('uri') as string;
-      this.photoPath = uri;
-      // this.savePicture(photoAsset);
+      this.savePicture(photoAsset);
     });
   }
 


### PR DESCRIPTION
# Summary

Closes https://github.com/react-native-oh-library/react-native-vision-camera/issues/64

- fixed：[Issues: #64] 修复拍照保存到相册的路径不是沙箱路径

## Test Plan

展示代码的稳定性。例如：用来复现场景的命令输入和结果输出、测试用例的路径地址，或者附上截图和视频。

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [x] 更新了 JS/TS 代码 (如有)

