### PR TITLE
fix：[Issues: #71] camera组件设置宽高不生效，设置resizemode影响取景器组件布局

### DIFF
--- a/package/harmony/vision_camera/src/main/ets/service/CameraSession.ts
+++ b/package/harmony/vision_camera/src/main/ets/service/CameraSession.ts
@@ -493,28 +493,24 @@ export default class CameraSession {
 
 
   //设置预览样式 cover/contain
-  setResizeMode(resizeMode: string, displayWidth: number = 1216, displayHeight: number = 2688,
+  setResizeMode(_resizeMode: string, displayWidth: number = 1216, displayHeight: number = 2688,
     callback: (width: number, height: number) => void) {
     let previewSize = this.previewProfile.size
     let screenAspect = displayWidth / displayHeight;
     let previewAspect = previewSize.height / previewSize.width;
     let componentWidth: number = 0;
     let componentHeight: number = 0;
+    let resizeMode = _resizeMode ?? 'cover';
     if (resizeMode === 'cover') {
-      if (screenAspect >= previewAspect) {
-        componentWidth = displayWidth;
-        componentHeight = displayWidth / previewAspect;
-      } else {
-        componentWidth = displayHeight * previewAspect;
-        componentHeight = displayHeight;
-      }
+      componentWidth = displayWidth;
+      componentHeight = displayHeight
     } else if (resizeMode === 'contain') {
       if (screenAspect >= previewAspect) {
         componentWidth = displayHeight * previewAspect;
         componentHeight = displayHeight;
       } else {
-        componentWidth = displayWidth;
-        componentHeight = displayWidth / previewAspect;
+        componentWidth = displayHeight / previewAspect;
+        componentHeight = displayHeight;
       }
     }
     // 计算设备左上角与预览流左上角偏移量

--- a/package/src/index.tsx
+++ b/package/src/index.tsx
@@ -30,7 +30,7 @@ import React, {
 } from "react";
 import {
     View,
-    DeviceEventEmitter,
+    DeviceEventEmitter,StyleSheet
 } from "react-native";
 import NativeVisionCameraView, { VisionCameraCommands } from "./NativeVisionCameraView";
 import type { VisionCameraCommandsType, VisionCameraComponentType } from "./NativeVisionCameraView";
@@ -470,11 +470,11 @@ export const Camera = forwardRef<VisionCameraRef, VisionCameraProps>(
         );
 
         return (
-            <View onTouchEnd={onVisionCameraTouchEnd}>
+            <View onTouchEnd={onVisionCameraTouchEnd} style={style} >
                 <NativeVisionCameraView
                     onCodeScanned={onVisionCameraCodeScanned}
                     ref={VisionCameraRef}
-                    style={style}
+                    style={StyleSheet.absoluteFill}
                     codeScanner={codeScanner}
                     fps={fps}
                     videoHdr={videoHdr}


### PR DESCRIPTION

Closes https://github.com/react-native-oh-library/react-native-vision-camera/issues/71
# Summary

- fix：[Issues: #71] camera组件设置宽高不生效，设置resizemode影响取景器组件布局


## Test Plan


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [x] 更新了 JS/TS 代码 (如有)
