### PR TITLE
fix:拍照失败添加错误提示

### DIFF
--- a/package/harmony/vision_camera/src/main/ets/manager/CommonManager.ts
+++ b/package/harmony/vision_camera/src/main/ets/manager/CommonManager.ts
@@ -108,7 +108,7 @@ export class CommonManager {
     if (ctx) {
       ctx.rnInstance?.emitDeviceEvent('onError', {
         nativeEvent: {
-          errorMessage: `${CommonManager.TAG}: ${message}`,
+          errorMessage: `${message}`,
         },
       });
     }

--- a/package/harmony/vision_camera/src/main/ets/manager/PhotoManager.ts
+++ b/package/harmony/vision_camera/src/main/ets/manager/PhotoManager.ts
@@ -232,7 +232,8 @@ export class PhotoManager {
       }
       await this.photoOutPut.capture(this.photoCaptureSetting);
     } catch (e) {
-      Logger.error(this.TAG, "Error capture: " + JSON.stringify(e))
+      Logger.error(this.TAG, "Error capture: " + JSON.stringify(e));
+      CommonManager.onError(this.ctx,"Error capture failed, please check camera permission.");
     }
     await this.waitForPathResult();
     let photoFile: PhotoFile = {} as PhotoFile;


### PR DESCRIPTION
# Summary

- fix:拍照失败添加错误提示
- Close: #109 

## Test Plan

 - 测试用例onError的demo，关闭拍照权限，点击拍照按钮，提示相应的错误信息
 - 已验证ok
## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
