### PR TITLE
fix:修复扫码时双指缩放触发crash问题

### DIFF
--- a/package/harmony/vision_camera/src/main/ets/view/VisionCameraView.ets
+++ b/package/harmony/vision_camera/src/main/ets/view/VisionCameraView.ets
@@ -46,6 +46,7 @@ import PreviewViewUtils, { CameraMode } from '../utils/PreviewViewUtils';
 import WindowUtil from '../utils/WindowUtil';
 import CameraManager from '../manager/CameraManager';
 import CameraConstants from '../datamodel/constant/CameraConstants';
+import { CommonManager } from '../manager/CommonManager';
 
 const previewViewType: Record<'surface-view' | 'texture-view', 'surface' | 'texture'> = {
   'surface-view': 'surface',
@@ -743,7 +744,11 @@ export struct VisionCameraView {
           // 在组件上绑定三指触发的捏合手势
           PinchGesture({ fingers: 2 })// 当捏合手势触发时，可以通过回调函数获取缩放比例，从而修改组件的缩放比例
             .onActionUpdate((event: GestureEvent) => {
-              this.scaleValue = this.cameraManager.getPhotoPreviewScale() * event.scale;
+              try {
+               this.scaleValue = this.cameraManager.getPhotoPreviewScale() * event.scale;
+              } catch (e) {
+                Logger.error(TAG,"Error get scaleValue failed");
+              }
             })
             .onActionEnd(() => {
               if (this.enableZoomGesture) {


### PR DESCRIPTION
# Summary

- fix:修复扫码时双指缩放触发crash问题
- Close: #112 

## Test Plan

- 测试扫码用例的demo，双指缩放触发镜头界面
- 已验证ok

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I have already compared the effects/features with the Android or iOS platforms
- [ ] I added a test for the API (if applicable)
- [ ] I have updated the JS/TS (if applicable)
- [ ] I updated the documentation (if applicable)
