### PR TITLE
fix:修复从非mp4格式切换到mp4格式执行录制异常问题

### DIFF
--- a/package/harmony/vision_camera/src/main/ets/manager/VideoManager.ts
+++ b/package/harmony/vision_camera/src/main/ets/manager/VideoManager.ts
@@ -512,6 +512,11 @@ export class VideoManager {
     xheight: number,
     deviceDegree: number,
   ) {
+    if (options.fileType && options.fileType !== media.ContainerFormatType.CFT_MPEG_4) {
+      CommonManager.onError(this.ctx, 'Video file encapsulation format. Only MP4 is supported.');
+      Logger.error(this.TAG, 'Video file encapsulation format. Only MP4 is supported.');
+      return;
+    }
     if (this.avRecorder.state === 'stopped' || this.avRecorder.state === 'idle' ||
       (this.avRecorder.state === 'prepared' && !props.videoHdr &&
         (this.uphasAudio || (this.currVideoCodec !== options.videoCodec)))) {
@@ -557,13 +562,7 @@ export class VideoManager {
         Logger.error(this.TAG, `restart recording error: ${JSON.stringify(error)}`);
       }
     }
-    if (options.fileType && options.fileType !== media.ContainerFormatType.CFT_MPEG_4) {
-      CommonManager.onError(this.ctx, 'Video file encapsulation format. Only MP4 is supported.');
-      Logger.error(this.TAG, 'Video file encapsulation format. Only MP4 is supported.');
-      return;
-    }
     this.setVideoFlashMode(options.flash);
-
     try {
       // 更新角度
       await this.avRecorder.updateRotation(this.getVideoRotation(this.videoOutput, deviceDegree));


### PR DESCRIPTION
# Summary

- fix:修复从非mp4格式切换到mp4格式执行录制异常问题
- Close: #116 

## Test Plan

- 执行rnt用例中的videoTestApp->onError
- 已验证ok

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)